### PR TITLE
Ensure FACEIT damage plugin auto-applies without commands

### DIFF
--- a/FriendlyNoTeammateBullets.cs
+++ b/FriendlyNoTeammateBullets.cs
@@ -1,10 +1,7 @@
 using CounterStrikeSharp.API;                         
 using CounterStrikeSharp.API.Core;                   
 using CounterStrikeSharp.API.Core.Attributes;        
-using CounterStrikeSharp.API.Modules.Commands;       
-using CounterStrikeSharp.API.Modules.Admin;          
-using CounterStrikeSharp.API.Core.Attributes.Registration; 
-using CounterStrikeSharp.API.Modules.Utils;          
+using CounterStrikeSharp.API.Core.Attributes.Registration;
 
 namespace FriendlyNoTeammateBullets;
 
@@ -23,7 +20,6 @@ public class FriendlyNoTeammateBulletsPlugin : BasePlugin
     public override void Load(bool hotReload)
     {
         ApplyFaceitLikeBulletFF();
-        AddCommand("css_ffbullets_apply", "Réapplique le profil no-teammate-bullets", OnApplyCmd);
     }
 
     [GameEventHandler]
@@ -31,12 +27,6 @@ public class FriendlyNoTeammateBulletsPlugin : BasePlugin
     {
         ApplyFaceitLikeBulletFF();
         return HookResult.Continue;
-    }
-
-    private void OnApplyCmd(CCSPlayerController? caller, CommandInfo cmd)
-    {
-        cmd.ReplyToCommand("[FFBullets] Réglages appliqués.");
-        ApplyFaceitLikeBulletFF();
     }
 
     private void ApplyFaceitLikeBulletFF()

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Un plugin **CounterStrikeSharp (CS2)** qui supprime les dégâts de balles entre
 ## Fonctionnalités
 - Annule les dégâts de balles entre mates (`ff_damage_reduction_bullets 0`).
 - Laisse actifs les autres types de dégâts (grenades, molotovs, flash).
-- Réapplique automatiquement les convars à chaque map / round.
-- Commande `!ffbullets_apply` pour réappliquer les réglages en jeu.
+- Applique automatiquement les convars au chargement du serveur et à chaque début de round.
 
 ## Installation
 1. Compiler :
@@ -20,9 +19,6 @@ Un plugin **CounterStrikeSharp (CS2)** qui supprime les dégâts de balles entre
    game/csgo/addons/counterstrikesharp/plugins/FriendlyNoTeammateBullets/
    ```
 3. Redémarrer le serveur.
-
-## Commandes
-- `!ffbullets_apply` — réapplique les réglages côté serveur.
 
 ## CI/CD (GitHub Actions)
 


### PR DESCRIPTION
## Summary
- remove the in-game command and related handler so the plugin simply auto-applies its settings
- keep applying the friendly-fire configuration when the plugin loads and at each round start
- update the README to reflect that the plugin runs automatically without any manual command

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8537cb4788322874e19a1b49efa87