### PR TITLE
Fix release workflow zip filename

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -109,6 +109,6 @@ jobs:
             collect/addons/counterstrikesharp/plugins/FACEITDamage/FACEITDamage.dll
             collect/README.md
             collect/addons/counterstrikesharp/configs/plugins/FACEITDamage/FACEITDamage.json
-            collect/advanced_friendlyfire-${{ inputs.tag_name }}.zip
+            collect/FACEITDamage-${{ inputs.tag_name }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update the release asset path to use the FACEITDamage zip name

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68c8566dd3c883228e4572e62c0a52d5